### PR TITLE
add recursive token evaluation and universal token eval script

### DIFF
--- a/src/dlg_i_dialogs.nss
+++ b/src/dlg_i_dialogs.nss
@@ -75,6 +75,7 @@ const string DLG_NO_HELLO      = "*NoHello";
 const string DLG_TOKEN         = "*Token";
 const string DLG_TOKEN_CACHE   = "*TokenCache";
 const string DLG_TOKEN_VALUES  = "*TokenValues";
+const string DLG_TOKEN_SCRIPT  = "*TokenScript";
 const string DLG_ACTION        = "*Action";
 const string DLG_ACTION_CHECK  = "*Check";
 const string DLG_ACTION_NODE   = "*Node";
@@ -1007,6 +1008,9 @@ string NormalizeDialogToken(string sToken)
     if (GetLocalInt(DIALOG, DLG_TOKEN + "*" + sToken))
         return sToken;
 
+    if (GetLocalString(DIALOG, DLG_TOKEN_SCRIPT) != "")
+        return sToken;
+
     string sLower = GetStringLowerCase(sToken);
     if (sToken == sLower || !GetLocalInt(DIALOG, DLG_TOKEN + "*" + sLower))
         return "";
@@ -1017,6 +1021,11 @@ string NormalizeDialogToken(string sToken)
 void SetDialogTokenValue(string sValue)
 {
     SetLocalString(GetPCSpeaker(), DLG_TOKEN, sValue);
+}
+
+void SetDialogTokenScript(string sScript)
+{
+    SetLocalString(DIALOG, DLG_TOKEN_SCRIPT, sScript);
 }
 
 void AddDialogToken(string sToken, string sEvalScript, string sValues = "")
@@ -1127,6 +1136,9 @@ string EvalDialogToken(string sToken, object oPC)
     }
 
     string sScript = GetLocalString(DIALOG, DLG_TOKEN + "*" + sNormal);
+    if (sScript == "")
+        sScript = GetLocalString(DIALOG, DLG_TOKEN_SCRIPT);
+    
     string sValues = GetLocalString(DIALOG, DLG_TOKEN_VALUES + "*" + sNormal);
 
     SetLocalString(oPC, DLG_TOKEN, sNormal);
@@ -1154,21 +1166,28 @@ string EvalDialogToken(string sToken, object oPC)
 string EvalDialogTokens(string sString)
 {
     object oPC = GetPCSpeaker();
-    json jTokens = RegExpIterate("<(.*?)>", sString);
-    if (jTokens == JSON_ARRAY)
-        return sString;
+    json jCheck = JSON_ARRAY;
 
-    jTokens = JsonArrayTransform(jTokens, JSON_ARRAY_UNIQUE);
-    
-    json jEval = JSON_ARRAY;
-    int n; for (n; n < JsonGetLength(jTokens); n++)
+    while (TRUE)
     {
-        string sToken = JsonGetString(JsonArrayGet(JsonArrayGet(jTokens, n), 1));
-        sString = RegExpReplace("<" + sToken + ">", sString, "^" + IntToString(n + 1));
-        jEval = JsonArrayInsert(jEval, JsonString(EvalDialogToken(sToken, oPC)));
+        json jTokens = RegExpIterate("<(?!c...>|/c>)(.*?)>", sString);
+        if (jTokens == JSON_ARRAY)
+            break;
+
+        jTokens = JsonArrayTransform(jTokens, JSON_ARRAY_UNIQUE);
+
+        if (jTokens == jCheck) break;
+        jCheck = jTokens;
+
+        json jEval = JSON_ARRAY;
+        int n; for (n; n < JsonGetLength(jTokens); n++)
+        {
+            string sToken = JsonGetString(JsonArrayGet(JsonArrayGet(jTokens, n), 1));
+            sString = SubstituteSubStrings(sString, "<" + sToken + ">", EvalDialogToken(sToken, oPC));
+        }
     }
 
-    return SubstituteString(sString, jEval, "^");
+    return sString;
 }
 
 // ----- System Functions ------------------------------------------------------

--- a/src/dlg_l_demo.nss
+++ b/src/dlg_l_demo.nss
@@ -307,13 +307,13 @@ void TokenDialog()
 
     AddDialogPage(TOKEN_PAGE_INFO,
         "I'm demonstrating the use of dialog tokens. A token is a word or " +
-        "choice in angle brackets such as <token>FullName</token>. Tokens " +
+        "choice in angle brackets such as <<FullName>>. Tokens " +
         "can be embedded directly into page or node text when initializing " +
         "the dialog and are evaluated at display time. This means you don't " +
         "need to know the value of the token to make the text work.");
     AddDialogPage(TOKEN_PAGE_INFO,
-        "There are lots of tokens available, such as <token>class</token>, " +
-        "<token>race</token>, and <token>level</token>.\n\n" +
+        "There are lots of tokens available, such as <<class>>, " +
+        "<<race>>, and <<level>>.\n\n" +
         "That's how I can know you're a level <level> <racial> <class>.");
     AddDialogPage(TOKEN_PAGE_INFO,
         "You can also add your own tokens using AddDialogToken() in your " +
@@ -329,18 +329,18 @@ void TokenDialog()
         "Some tokens can have uppercase and lowercase variants. When the " +
         "token is all lowercase, the value will be converted to lowercase; " +
         "otherwise the value will be used as is. For example:\n\n" +
-        "<token>Class</token> -> <Class>\n" +
-        "<token>class</token> -> <class>");
+        "<<Class>> -> <Class>\n" +
+        "<<class>> -> <class>");
     AddDialogPage(TOKEN_PAGE_INFO,
         "Some tokens cannot be converted to lowercase; if there are any " +
         "uppercase characters in sToken, the text must be typed exactly and " +
         "its value will always be exact. For example:\n\n" +
-        "<token>FullName</token> -> <FullName>\n" +
-        "<token>fullname</token> -> <fullname>");
+        "<<FullName>> -> <FullName>\n" +
+        "<<fullname>> -> <fullname>");
     string sPage = AddDialogPage(TOKEN_PAGE_INFO,
         "Tokens are specific to a dialog, so if you add your own tokens, you " +
         "don't have to worry about making them unique across all dialogs. " +
-        "You could have a <token>value</token> token in two different " +
+        "You could have a <<value>> token in two different " +
         "dialogs that are evaluated by different library scripts. This gives " +
         "you a lot of flexibility when designing dialogs.");
     EnableDialogNode(DLG_NODE_BACK, sPage);
@@ -348,66 +348,67 @@ void TokenDialog()
 
     AddDialogPage(TOKEN_PAGE_LIST,
         "Gender tokens (case insensitive):\n\n" +
-        "- <token>bitch/bastard</token> -> <bitch/bastard>\n" +
-        "- <token>boy/girl</token> -> <boy/girl>\n" +
-        "- <token>brother/sister</token> -> <brother/sister>\n" +
-        "- <token>he/she</token> -> <he/she>\n" +
-        "- <token>him/her</token> -> <him/her>\n" +
-        "- <token>his/her</token> -> <his/her>\n" +
-        "- <token>his/hers</token> -> <his/hers>\n" +
-        "- <token>lad/lass</token> -> <lad/lass>\n" +
-        "- <token>lord/lady</token> -> <lord/lady>\n" +
-        "- <token>male/female</token> -> <male/female>\n" +
-        "- <token>man/woman</token> -> <man/woman>\n" +
-        "- <token>master/mistress</token> -> <master/mistress>\n" +
-        "- <token>mister/missus</token> -> <mister/missus>\n" +
-        "- <token>sir/madam</token> -> <sir/madam>");
+        "- <<bitch/bastard>> -> <bitch/bastard>\n" +
+        "- <<boy/girl>> -> <boy/girl>\n" +
+        "- <<brother/sister>> -> <brother/sister>\n" +
+        "- <<bitch/bastard>> -> <bitch/bastard>\n" +
+        "- <<bitch/bastard>> -> <bitch/bastard>\n" +
+        "- <<he/she>> -> <he/she>\n" +
+        "- <<him/her>> -> <him/her>\n" +
+        "- <<his/her>> -> <his/her>\n" +
+        "- <<his/hers>> -> <his/hers>\n" +
+        "- <<bitch/bastard>> -> <bitch/bastard>\n" +
+        "- <<lad/lass>> -> <lad/lass>\n" +
+        "- <<lord/lady>> -> <lord/lady>\n" +
+        "- <<male/female>> -> <male/female>\n" +
+        "- <<man/woman>> -> <man/woman>\n" +
+        "- <<master/mistress>> -> <master/mistress>\n" +
+        "- <<mister/missus>> -> <mister/missus>\n" +
+        "- <<sir/madam>> -> <sir/madam>");
     AddDialogPage(TOKEN_PAGE_LIST,
         "Alignment tokens (case insensitive):\n\n" +
-        "- <token>alignment</token> -> <alignment>\n" +
-        "- <token>good/evil</token> -> <good/evil>\n" +
-        "- <token>law/chaos</token> -> <law/chaos>\n" +
-        "- <token>lawful/chaotic</token> -> <lawful/chaotic>");
+        "- <<alignment>> -> <alignment>\n" +
+        "- <<good/evil>> -> <good/evil>\n" +
+        "- <<law/chaos>> -> <law/chaos>\n" +
+        "- <<lawful/chaotic>> -> <lawful/chaotic>");
     AddDialogPage(TOKEN_PAGE_LIST,
         "Character tokens (case insensitive):\n\n" +
-        "- <token>class</token> -> <class>\n" +
-        "- <token>classes</token> -> <classes>\n" +
-        "- <token>level</token> -> <level>\n" +
-        "- <token>race</token> -> <race>\n" +
-        "- <token>races</token> -> <races>\n" +
-        "- <token>racial</token> -> <racial>\n" +
-        "- <token>subrace</token> -> <subrace>\n\n" +
+        "- <<class>> -> <class>\n" +
+        "- <<classes>> -> <classes>\n" +
+        "- <<level>> -> <level>\n" +
+        "- <<race>> -> <race>\n" +
+        "- <<races>> -> <races>\n" +
+        "- <<racial>> -> <racial>\n" +
+        "- <<subrace>> -> <subrace>\n\n" +
         "Character tokens (case sensitive):\n\n" +
-        "- <token>Deity</token> -> <Deity>");
+        "- <<Deity>> -> <Deity>");
     AddDialogPage(TOKEN_PAGE_LIST,
         "Time tokens (case insensitive):\n\n" +
-        "- <token>day/night</token> -> <day/night>\n" +
-        "- <token>gameday</token> -> <gameday>\n" +
-        "- <token>gamedate</token> -> <gamedate>\n" +
-        "- <token>gamehour</token> -> <gamehour>\n" +
-        "- <token>gameminute</token> -> <gameminute>\n" +
-        "- <token>gamemonth</token> -> <gamemonth>\n" +
-        "- <token>gamesecond</token> -> <gamesecond>\n" +
-        "- <token>gametime12</token> -> <gametime12>\n" +
-        "- <token>gametime24</token> -> <gametime24>\n" +
-        "- <token>gameyear</token> -> <gameyear>\n" +
-        "- <token>quarterday</token> -> <quarterday>");
+        "- <<day/night>> -> <day/night>\n" +
+        "- <<gameday>> -> <gameday>\n" +
+        "- <<gamedate>> -> <gamedate>\n" +
+        "- <<gamehour>> -> <gamehour>\n" +
+        "- <<gameminute>> -> <gameminute>\n" +
+        "- <<gamemonth>> -> <gamemonth>\n" +
+        "- <<gamesecond>> -> <gamesecond>\n" +
+        "- <<gametime12>> -> <gametime12>\n" +
+        "- <<gametime24>> -> <gametime24>\n" +
+        "- <<gameyear>> -> <gameyear>\n" +
+        "- <<quarterday>> -> <quarterday>");
     AddDialogPage(TOKEN_PAGE_LIST,
         "Name tokens (case sensitive):\n\n" +
-        "- <token>FirstName</token> -> <FirstName>\n" +
-        "- <token>FullName</token> -> <FullName>\n" +
-        "- <token>LastName</token> -> <LastName>\n" +
-        "- <token>PlayerName</token> -> <PlayerName>");
+        "- <<FirstName>> -> <FirstName>\n" +
+        "- <<FullName>> -> <FullName>\n" +
+        "- <<LastName>> -> <LastName>\n" +
+        "- <<PlayerName>> -> <PlayerName>");
     sPage = AddDialogPage(TOKEN_PAGE_LIST,
         "Special tokens (case sensitive):\n\n" +
-        "- <token>StartAction</token>foo<token>/Start</token> -> " +
+        "- <<StartAction>>foo<</Start>> -> " +
             "<StartAction>foo</Start>\n" +
-        "- <token>StartCheck</token>foo<token>/Start</token> -> " +
+        "- <<StartCheck>>foo<</Start>> -> " +
             "<StartCheck>foo</Start>\n" +
-        "- <token>StartHighlight</token>foo<token>/Start</token> -> " +
-            "<StartHighlight>foo</Start>\n\n" +
-        "Special tokens (case insensitive):\n\n" +
-        "- <token>token</token>foo<token>/token</token> -> <token>foo</token>");
+        "- <<StartHighlight>>foo<</Start>> -> " +
+            "<StartHighlight>foo</Start>");
     EnableDialogNode(DLG_NODE_BACK, sPage);
     SetDialogTarget("Main Page", sPage, DLG_NODE_BACK);
 }


### PR DESCRIPTION
Recursive token evaluation allows evaluated tokens to return other tokens, which will then be re-evaluated in a recursive loop until there are either no tokens remaining to evaluate, or the same tokens are returned more than once (indicating they cannot be evaluated).

Additionally, I had to remove `RegExpReplace` functionality in `EvalDialogTokens()` because the function would fail if the token's name contained any characters that are reserved characters for regex, including special characters like [.+^] etc.

Finally, I added `SetDialogTokenScript()`.  This function sets a universal token evaluation function for any encountered token that was not added *correctly* using `AddDialogToken()`.  It does not allow for that passage of a specific value set like `AddDialogToken()` does, but it does allow for a universal token evaluation function that can evaluate tokens that are not pre-defined.  If a token was added (and script defined) with `AddDialogToken()`, that script will take priority over the script set with `SetDialogTokenScript()`, so the functions can live side-by-side without conflict.